### PR TITLE
Doesn't build on GHC 7.0

### DIFF
--- a/hslua.cabal
+++ b/hslua.cabal
@@ -41,7 +41,7 @@ flag luajit
   default:              False
 
 library
-  build-depends:        base == 4.*, bytestring >= 0.10.2.0 && < 0.11
+  build-depends:        base >= 4.4 && < 5, bytestring >= 0.10.2.0 && < 0.11
   exposed-modules:      Scripting.Lua, Scripting.Lua.Raw
   hs-source-dirs:       src
   ghc-options:          -Wall -O2


### PR DESCRIPTION
```
src/Scripting/Lua.hsc:552:10:
    Illegal instance declaration for `StackValue LuaInteger'
      (All instance types must be of the form (T t1 ... tn)
       where T is not a synonym.
       Use -XTypeSynonymInstances if you want to disable this.)
    In the instance declaration for `StackValue LuaInteger'

src/Scripting/Lua.hsc:557:10:
    Illegal instance declaration for `StackValue LuaNumber'
      (All instance types must be of the form (T t1 ... tn)
       where T is not a synonym.
       Use -XTypeSynonymInstances if you want to disable this.)
    In the instance declaration for `StackValue LuaNumber'
xcabal: Error: some packages failed to install:
```

Only applies to the latest version, I revised it: http://hackage.haskell.org/package/hslua-0.4.0/revisions/