### PR TITLE
Fix `peek` defined in the StackValue instance for lists

### DIFF
--- a/src/Scripting/Lua.hsc
+++ b/src/Scripting/Lua.hsc
@@ -142,6 +142,7 @@ tolist l n = do
     iter (i : is) = do
       rawgeti l n i
       ret <- peek l (-1)
+      pop l 1
       case ret of
         Nothing  -> return Nothing
         Just val -> do


### PR DESCRIPTION
Hi! The StackValue instance for lists is broken as evidenced by the following -

    *Scripting.LuaUtils> l <- Lua.newstate
    *Scripting.LuaUtils> dumpStack l
      <stack>
      </stack>
    *Scripting.LuaUtils> Lua.push l [100::Int]
    *Scripting.LuaUtils> dumpStack l
      <stack>
        <table>
          100
        </table>
      </stack>
    *Scripting.LuaUtils> x::Maybe [Int] <- Lua.peek l (-1)
    *Scripting.LuaUtils> x
      Just [100]
    *Scripting.LuaUtils> dumpStack l
      <stack>
        100
        <table>
          100
        </table>
      </stack>
    *Scripting.LuaUtils>

It seems that the `peek` function does not clean up the stack properly. This patch fixes that issue.

Note that this bug is currently causing a test to fail for `luautils` (https://github.com/ajnsit/luautils/issues/4). The test passes after implementing this patch.
