### PR TITLE
Add stack support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *dist/*
 .cabal-sandbox*
+.stack-work
 *.hi
 *.o

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,7 @@
+flags: {}
+packages:
+- '.'
+extra-deps:
+- hspec-contrib-0.3.0
+resolver: lts-2.21
+


### PR DESCRIPTION
I added a stack.yaml file with the latest lts-haskell release. Should be useful to people who build hslua with stack instead of cabal.
