### PR TITLE
Put links in haddock comments and deprecated strlen

### DIFF
--- a/src/Scripting/Lua.hsc
+++ b/src/Scripting/Lua.hsc
@@ -34,7 +34,7 @@ import Scripting.Lua.Raw
 
 #include "lua.h"
 
--- | Enumeration used as type tag. See @lua_type@ in Lua Reference Manual.
+-- | Enumeration used as type tag. See <https://www.lua.org/manual/5.1/manual.html#lua_type lua_type>.
 data LTYPE
     = TNONE
     | TNIL
@@ -84,51 +84,51 @@ data GCCONTROL
     | GCSETSTEPMUL
     deriving (Eq,Ord,Show,Enum)
 
--- | See @LUA_MULTRET@ in Lua Reference Manual.
+-- | Alias for C constant @LUA_MULTRET@. See <https://www.lua.org/manual/5.1/manual.html#lua_call lua_call>.
 multret :: Int
 multret = #{const LUA_MULTRET}
 
--- | See @lua_settop@ in Lua Reference Manual.
+-- | See <https://www.lua.org/manual/5.1/manual.html#lua_settop lua_settop>.
 settop :: LuaState -> Int -> IO ()
 settop l n = c_lua_settop l (fromIntegral n)
 
--- | See @lua_createtable@ in Lua Reference Manual.
+-- | See <https://www.lua.org/manual/5.1/manual.html#lua_createtable lua_createtable>.
 createtable :: LuaState -> Int -> Int -> IO ()
 createtable l s z = c_lua_createtable l (fromIntegral s) (fromIntegral z)
 
--- | See @lua_objlen@ in Lua Reference Manual.
+-- | See <https://www.lua.org/manual/5.1/manual.html#lua_objlen lua_objlen>.
 objlen :: LuaState -> Int -> IO Int
 objlen l n = liftM fromIntegral (c_lua_objlen l (fromIntegral n))
 
--- | See @lua_pop@ in Lua Reference Manual.
+-- | See <https://www.lua.org/manual/5.1/manual.html#lua_pop lua_pop>.
 pop :: LuaState -> Int -> IO ()
 pop l n = settop l (-n-1)
 
--- | See @lua_newtable@ in Lua Reference Manual.
+-- | See <https://www.lua.org/manual/5.1/manual.html#lua_newtable lua_newtable>.
 newtable :: LuaState -> IO ()
 newtable l = createtable l 0 0
 
--- | See @lua_pushcclosure@ in Lua Reference Manual.
+-- | See <https://www.lua.org/manual/5.1/manual.html#lua_pushcclosure lua_pushcclosure>.
 pushcclosure :: LuaState -> FunPtr LuaCFunction -> Int -> IO ()
 pushcclosure l f n = c_lua_pushcclosure l f (fromIntegral n)
 
--- | See @lua_pushcfunction@ in Lua Reference Manual.
+-- | See <https://www.lua.org/manual/5.1/manual.html#lua_pushcfunction lua_pushcfunction>.
 pushcfunction :: LuaState -> FunPtr LuaCFunction -> IO ()
 pushcfunction l f = pushcclosure l f 0
 
--- | See @lua_strlen@ in Lua Reference Manual.
+-- | Compatibility alias for objlen
 strlen :: LuaState -> Int -> IO Int
 strlen = objlen
 
--- | See @lua_type@ in Lua Reference Manual.
+-- | See <https://www.lua.org/manual/5.1/manual.html#lua_type lua_type>.
 ltype :: LuaState -> Int -> IO LTYPE
 ltype l n = liftM (toEnum . fromIntegral) (c_lua_type l (fromIntegral n))
 
--- | See @lua_isfunction@ in Lua Reference Manual.
+-- | See <https://www.lua.org/manual/5.1/manual.html#lua_isfunction lua_isfunction>.
 isfunction :: LuaState -> Int -> IO Bool
 isfunction l n = liftM (== TFUNCTION) (ltype l n)
 
--- | See @lua_istable@ in Lua Reference Manual.
+-- | See <https://www.lua.org/manual/5.1/manual.html#lua_istable lua_istable>.
 istable :: LuaState -> Int -> IO Bool
 istable l n = liftM (== TTABLE) (ltype l n)
 
@@ -151,82 +151,82 @@ tolist l n = do
                      Nothing -> Nothing
                      Just vals -> Just (val : vals)
 
--- | See @lua_islightuserdata@ in Lua Reference Manual.
+-- | See <https://www.lua.org/manual/5.1/manual.html#lua_islightuserdata lua_islightuserdata>.
 islightuserdata :: LuaState -> Int -> IO Bool
 islightuserdata l n = liftM (== TLIGHTUSERDATA) (ltype l n)
 
--- | See @lua_isnil@ in Lua Reference Manual.
+-- | See <https://www.lua.org/manual/5.1/manual.html#lua_isnil lua_isnil>.
 isnil :: LuaState -> Int -> IO Bool
 isnil l n = liftM (== TNIL) (ltype l n)
 
--- | See @lua_isboolean@ in Lua Reference Manual.
+-- | See <https://www.lua.org/manual/5.1/manual.html#lua_isboolean lua_isboolean>.
 isboolean :: LuaState -> Int -> IO Bool
 isboolean l n = liftM (== TBOOLEAN) (ltype l n)
 
--- | See @lua_isthread@ in Lua Reference Manual.
+-- | See <https://www.lua.org/manual/5.1/manual.html#lua_isthread lua_isthread>.
 isthread :: LuaState -> Int -> IO Bool
 isthread l n = liftM (== TTHREAD) (ltype l n)
 
--- | See @lua_none@ in Lua Reference Manual.
+-- | See <https://www.lua.org/manual/5.1/manual.html#lua_isnone lua_isnone>.
 isnone :: LuaState -> Int -> IO Bool
 isnone l n = liftM (== TNONE) (ltype l n)
 
--- | See @lua_noneornil@ in Lua Reference Manual.
+-- | See <https://www.lua.org/manual/5.1/manual.html#lua_isnoneornil lua_isnoneornil>.
 isnoneornil :: LuaState -> Int -> IO Bool
 isnoneornil l n = liftM (<= TNIL) (ltype l n)
 
--- | See @LUA_REGISTRYINDEX@ in Lua Reference Manual.
+-- | Alias for C constant @LUA_REGISTRYINDEX@. See <https://www.lua.org/manual/5.1/manual.html#3.5 Lua registry>.
 registryindex :: Int
 registryindex = #{const LUA_REGISTRYINDEX}
 
--- | See @LUA_ENVIRONINDEX@ in Lua Reference Manual.
+-- | Alias for C constant @LUA_ENVIRONINDEX@. See <https://www.lua.org/manual/5.1/manual.html#3.3 pseudo-indices>.
 environindex :: Int
 environindex = #{const LUA_ENVIRONINDEX}
 
--- | See @LUA_GLOBALSINDEX@ in Lua Reference Manual.
+-- | Alias for C constant @LUA_GLOBALSINDEX@. See <https://www.lua.org/manual/5.1/manual.html#3.3 pseudo-indices>.
 globalsindex :: Int
 globalsindex = #{const LUA_GLOBALSINDEX}
 
--- | See @lua_upvalueindex@ in Lua Reference Manual.
+-- | See <https://www.lua.org/manual/5.1/manual.html#lua_upvalueindex lua_upvalueindex>.
 upvalueindex :: Int -> Int
 upvalueindex i = globalsindex - i
 
--- | See @lua_atpanic@ in Lua Reference Manual.
+-- | See <https://www.lua.org/manual/5.1/manual.html#lua_atpanic lua_atpanic>.
 atpanic :: LuaState -> FunPtr LuaCFunction -> IO (FunPtr LuaCFunction)
 atpanic = c_lua_atpanic
 
--- | See @lua_tostring@ in Lua Reference Manual.
+-- | See <https://www.lua.org/manual/5.1/manual.html#lua_tostring lua_tostring>.
 tostring :: LuaState -> Int -> IO B.ByteString
 tostring l n = alloca $ \lenPtr -> do
     cstr <- c_lua_tolstring l (fromIntegral n) lenPtr
     cstrLen <- F.peek lenPtr
     B.packCStringLen (cstr, fromIntegral cstrLen)
 
--- | See @lua_tothread@ in Lua Reference Manual.
+-- | See <https://www.lua.org/manual/5.1/manual.html#lua_tothread lua_tothread>.
 tothread :: LuaState -> Int -> IO LuaState
 tothread l n = c_lua_tothread l (fromIntegral n)
 
--- | See @lua_touserdata@ in Lua Reference Manual.
+-- | See <https://www.lua.org/manual/5.1/manual.html#lua_touserdata lua_touserdata>.
 touserdata :: LuaState -> Int -> IO (Ptr a)
 touserdata l n = c_lua_touserdata l (fromIntegral n)
 
--- | See @lua_typename@ in Lua Reference Manual.
+-- | See <https://www.lua.org/manual/5.1/manual.html#lua_typename lua_typename>.
 typename :: LuaState -> LTYPE -> IO String
 typename l n = c_lua_typename l (fromIntegral (fromEnum n)) >>= peekCString
 
--- | See @lua_xmove@ in Lua Reference Manual.
+-- | See <https://www.lua.org/manual/5.1/manual.html#lua_xmove lua_xmove>.
 xmove :: LuaState -> LuaState -> Int -> IO ()
 xmove l1 l2 n = c_lua_xmove l1 l2 (fromIntegral n)
 
--- | See @lua_yield@ in Lua Reference Manual.
+-- | See <https://www.lua.org/manual/5.1/manual.html#lua_yield lua_yield>.
 yield :: LuaState -> Int -> IO Int
 yield l n = liftM fromIntegral (c_lua_yield l (fromIntegral n))
 
--- | See @lua_checkstack@ in Lua Reference Manual.
+-- | See <https://www.lua.org/manual/5.1/manual.html#lua_checkstack lua_checkstack>.
 checkstack :: LuaState -> Int -> IO Bool
 checkstack l n = liftM (/= 0) (c_lua_checkstack l (fromIntegral n))
 
--- | See @lua_newstate@ and @luaL_newstate@ in Lua Reference Manual.
+-- | See @lua_newstate@ and <https://www.lua.org/manual/5.1/manual.html#luaL_newstate luaL_newstate>.
 newstate :: IO LuaState
 newstate = do
     l <- c_luaL_newstate
@@ -234,73 +234,81 @@ newstate = do
     setglobal l "_HASKELLERR"
     return l
 
--- | See @lua_close@ in Lua Reference Manual.
+-- | See <https://www.lua.org/manual/5.1/manual.html#lua_close lua_close>.
 close :: LuaState -> IO ()
 close = c_lua_close
 
--- | See @lua_concat@ in Lua Reference Manual.
+-- | See <https://www.lua.org/manual/5.1/manual.html#lua_concat lua_concat>.
 concat :: LuaState -> Int -> IO ()
 concat l n = c_lua_concat l (fromIntegral n)
 
--- | See @lua_call@ and @lua_call@ in Lua Reference Manual.
+-- | See @lua_call@ and <https://www.lua.org/manual/5.1/manual.html#lua_call lua_call>.
 call :: LuaState -> Int -> Int -> IO ()
 call l a b = c_lua_call l (fromIntegral a) (fromIntegral b)
 
--- | See @lua_pcall@ in Lua Reference Manual.
+-- | See <https://www.lua.org/manual/5.1/manual.html#lua_pcall lua_pcall>.
 pcall :: LuaState -> Int -> Int -> Int -> IO Int
 pcall l a b c = liftM fromIntegral (c_lua_pcall l (fromIntegral a) (fromIntegral b) (fromIntegral c))
 
--- | See @lua_cpcall@ in Lua Reference Manual.
+-- | See <https://www.lua.org/manual/5.1/manual.html#lua_cpcall lua_cpcall>.
 cpcall :: LuaState -> FunPtr LuaCFunction -> Ptr a -> IO Int
 cpcall l a c = liftM fromIntegral (c_lua_cpcall l a c)
 
--- | See @lua_getfield@ in Lua Reference Manual.
+-- | See <https://www.lua.org/manual/5.1/manual.html#lua_getfield lua_getfield>.
 getfield :: LuaState -> Int -> String -> IO ()
 getfield l i s = withCString s $ \sPtr -> c_lua_getfield l (fromIntegral i) sPtr
 
--- | See @lua_setfield@ in Lua Reference Manual.
+-- | See <https://www.lua.org/manual/5.1/manual.html#lua_setfield lua_setfield>.
 setfield :: LuaState -> Int -> String -> IO ()
 setfield l i s = withCString s $ \sPtr -> c_lua_setfield l (fromIntegral i) sPtr
 
--- | See @lua_getglobal@ in Lua Reference Manual.
+-- | See <https://www.lua.org/manual/5.1/manual.html#lua_getglobal lua_getglobal>.
 getglobal :: LuaState -> String -> IO ()
 getglobal l n = getfield l globalsindex n
 
--- | See @lua_setglobal@ in Lua Reference Manual.
+-- | See <https://www.lua.org/manual/5.1/manual.html#lua_setglobal lua_setglobal>.
 setglobal :: LuaState -> String -> IO ()
 setglobal l n = setfield l globalsindex n
 
--- | See @luaL_openlibs@ in Lua Reference Manual.
+-- | See <https://www.lua.org/manual/5.1/manual.html#luaL_openlibs luaL_openlibs>.
 openlibs :: LuaState -> IO ()
 openlibs = c_luaL_openlibs
 
+-- | See <https://www.lua.org/manual/5.1/manual.html#pdf-luaopen_base luaopen_base>.
 openbase :: LuaState -> IO ()
 openbase l = pushcfunction l c_lua_open_base_ptr >> call l 0 multret
 
+-- | See <https://www.lua.org/manual/5.1/manual.html#pdf-luaopen_table luaopen_table>.
 opentable :: LuaState -> IO ()
 opentable l = pushcfunction l c_lua_open_table_ptr >> call l 0 multret
 
+-- | See <https://www.lua.org/manual/5.1/manual.html#pdf-luaopen_io luaopen_io>.
 openio :: LuaState -> IO ()
 openio l = pushcfunction l c_lua_open_io_ptr >> call l 0 multret
 
+-- | See <https://www.lua.org/manual/5.1/manual.html#pdf-luaopen_os luaopen_os>.
 openos :: LuaState -> IO ()
 openos l = pushcfunction l c_lua_open_os_ptr >> call l 0 multret
 
+-- | See <https://www.lua.org/manual/5.1/manual.html#pdf-luaopen_string luaopen_string>.
 openstring :: LuaState -> IO ()
 openstring l = pushcfunction l c_lua_open_string_ptr >> call l 0 multret
 
+-- | See <https://www.lua.org/manual/5.1/manual.html#pdf-luaopen_math luaopen_math>.
 openmath :: LuaState -> IO ()
 openmath l = pushcfunction l c_lua_open_math_ptr >> call l 0 multret
 
+-- | See <https://www.lua.org/manual/5.1/manual.html#pdf-luaopen_debug luaopen_debug>.
 opendebug :: LuaState -> IO ()
 opendebug l = pushcfunction l c_lua_open_debug_ptr >> call l 0 multret
 
+-- | See <https://www.lua.org/manual/5.1/manual.html#pdf-luaopen_package luaopen_package>.
 openpackage :: LuaState -> IO ()
 openpackage l = pushcfunction l c_lua_open_package_ptr >> call l 0 multret
 
 foreign import ccall "wrapper" mkStringWriter :: LuaWriter -> IO (FunPtr LuaWriter)
 
--- | See @lua_dump@ in Lua Reference Manual.
+-- | See <https://www.lua.org/manual/5.1/manual.html#lua_dump lua_dump>.
 dump :: LuaState -> IO String
 dump l = do
     r <- newIORef ""
@@ -314,7 +322,7 @@ dump l = do
     freeHaskellFunPtr writer
     readIORef r
 
--- | See @lua_equal@ in Lua Reference Manual.
+-- | See <https://www.lua.org/manual/5.1/manual.html#lua_equal lua_equal>.
 equal :: LuaState -> Int -> Int -> IO Bool
 equal l i j = liftM (/= 0) (c_lua_equal l (fromIntegral i) (fromIntegral j))
 
@@ -328,92 +336,92 @@ lerror l = do
     insert l (-2)
     return 2
 
--- | See @lua_gc@ in Lua Reference Manual.
+-- | See <https://www.lua.org/manual/5.1/manual.html#lua_gc lua_gc>.
 gc :: LuaState -> GCCONTROL -> Int -> IO Int
 gc l i j= liftM fromIntegral (c_lua_gc l (fromIntegral (fromEnum i)) (fromIntegral j))
 
--- | See @lua_getfenv@ in Lua Reference Manual.
+-- | See <https://www.lua.org/manual/5.1/manual.html#lua_getfenv lua_getfenv>.
 getfenv :: LuaState -> Int -> IO ()
 getfenv l n = c_lua_getfenv l (fromIntegral n)
 
--- | See @lua_getmetatable@ in Lua Reference Manual.
+-- | See <https://www.lua.org/manual/5.1/manual.html#lua_getmetatable lua_getmetatable>.
 getmetatable :: LuaState -> Int -> IO Bool
 getmetatable l n = liftM (/= 0) (c_lua_getmetatable l (fromIntegral n))
 
--- | See @lua_gettable@ in Lua Reference Manual.
+-- | See <https://www.lua.org/manual/5.1/manual.html#lua_gettable lua_gettable>.
 gettable :: LuaState -> Int -> IO ()
 gettable l n = c_lua_gettable l (fromIntegral n)
 
--- | See @lua_gettop@ in Lua Reference Manual.
+-- | See <https://www.lua.org/manual/5.1/manual.html#lua_gettop lua_gettop>.
 gettop :: LuaState -> IO Int
 gettop l = liftM fromIntegral (c_lua_gettop l)
 
--- | See @lua_insert@ in Lua Reference Manual.
+-- | See <https://www.lua.org/manual/5.1/manual.html#lua_insert lua_insert>.
 insert :: LuaState -> Int -> IO ()
 insert l n  = c_lua_insert l (fromIntegral n)
 
--- | See @lua_iscfunction@ in Lua Reference Manual.
+-- | See <https://www.lua.org/manual/5.1/manual.html#lua_iscfunction lua_iscfunction>.
 iscfunction :: LuaState -> Int -> IO Bool
 iscfunction l n = liftM (/= 0) (c_lua_iscfunction l (fromIntegral n))
 
--- | See @lua_isnumber@ in Lua Reference Manual.
+-- | See <https://www.lua.org/manual/5.1/manual.html#lua_isnumber lua_isnumber>.
 isnumber :: LuaState -> Int -> IO Bool
 isnumber l n = liftM (/= 0) (c_lua_isnumber l (fromIntegral n))
 
--- | See @lua_isstring@ in Lua Reference Manual.
+-- | See <https://www.lua.org/manual/5.1/manual.html#lua_isstring lua_isstring>.
 isstring :: LuaState -> Int -> IO Bool
 isstring l n = liftM (/= 0) (c_lua_isstring l (fromIntegral n))
 
--- | See @lua_isuserdata@ in Lua Reference Manual.
+-- | See <https://www.lua.org/manual/5.1/manual.html#lua_isuserdata lua_isuserdata>.
 isuserdata :: LuaState -> Int -> IO Bool
 isuserdata l n = liftM (/= 0) (c_lua_isuserdata l (fromIntegral n))
 
--- | See @lua_lessthan@ in Lua Reference Manual.
+-- | See <https://www.lua.org/manual/5.1/manual.html#lua_lessthan lua_lessthan>.
 lessthan :: LuaState -> Int -> Int -> IO Bool
 lessthan l i j = liftM (/= 0) (c_lua_lessthan l (fromIntegral i) (fromIntegral j))
 
 
--- | See @luaL_loadfile@ in Lua Reference Manual.
+-- | See <https://www.lua.org/manual/5.1/manual.html#luaL_loadfile luaL_loadfile>.
 loadfile :: LuaState -> String -> IO Int
 loadfile l f = withCString f $ \fPtr -> fmap fromIntegral (c_luaL_loadfile l fPtr)
 
--- | See @luaL_loadstring@ in Lua Reference Manual.
+-- | See <https://www.lua.org/manual/5.1/manual.html#luaL_loadstring luaL_loadstring>.
 loadstring :: LuaState -> String -> IO Int
 loadstring l str = withCString str $ \strPtr -> fmap fromIntegral (c_luaL_loadstring l strPtr)
 
--- | See @lua_newthread@ in Lua Reference Manual.
+-- | See <https://www.lua.org/manual/5.1/manual.html#lua_newthread lua_newthread>.
 newthread :: LuaState -> IO LuaState
 newthread l = c_lua_newthread l
 
--- | See @lua_newuserdata@ in Lua Reference Manual.
+-- | See <https://www.lua.org/manual/5.1/manual.html#lua_newuserdata lua_newuserdata>.
 newuserdata :: LuaState -> Int -> IO (Ptr ())
 newuserdata l s = c_lua_newuserdata l (fromIntegral s)
 
--- | See @lua_next@ in Lua Reference Manual.
+-- | See <https://www.lua.org/manual/5.1/manual.html#lua_next lua_next>.
 next :: LuaState -> Int -> IO Bool
 next l i = liftM (/= 0) (c_lua_next l (fromIntegral i))
 
--- | See @lua_pushboolean@ in Lua Reference Manual.
+-- | See <https://www.lua.org/manual/5.1/manual.html#lua_pushboolean lua_pushboolean>.
 pushboolean :: LuaState -> Bool -> IO ()
 pushboolean l v = c_lua_pushboolean l (fromIntegral (fromEnum v))
 
--- | See @lua_pushinteger@ in Lua Reference Manual.
+-- | See <https://www.lua.org/manual/5.1/manual.html#lua_pushinteger lua_pushinteger>.
 pushinteger :: LuaState -> LuaInteger -> IO ()
 pushinteger = c_lua_pushinteger
 
--- | See @lua_pushlightuserdata@ in Lua Reference Manual.
+-- | See <https://www.lua.org/manual/5.1/manual.html#lua_pushlightuserdata lua_pushlightuserdata>.
 pushlightuserdata :: LuaState -> Ptr a -> IO ()
 pushlightuserdata = c_lua_pushlightuserdata
 
--- | See @lua_pushnil@ in Lua Reference Manual.
+-- | See <https://www.lua.org/manual/5.1/manual.html#lua_pushnil lua_pushnil>.
 pushnil :: LuaState -> IO ()
 pushnil = c_lua_pushnil
 
--- | See @lua_pushnumber@ in Lua Reference Manual.
+-- | See <https://www.lua.org/manual/5.1/manual.html#lua_pushnumber lua_pushnumber>.
 pushnumber :: LuaState -> LuaNumber -> IO ()
 pushnumber = c_lua_pushnumber
 
--- | See @lua_pushstring@ in Lua Reference Manual.
+-- | See <https://www.lua.org/manual/5.1/manual.html#lua_pushstring lua_pushstring>.
 pushstring :: LuaState -> B.ByteString -> IO ()
 pushstring l s = B.unsafeUseAsCStringLen s $ \(sPtr, z) -> c_lua_pushlstring l sPtr (fromIntegral z)
 
@@ -425,94 +433,94 @@ pushlist l list = do
       push l val
       rawseti l (-2) idx
 
--- | See @lua_pushthread@ in Lua Reference Manual.
+-- | See <https://www.lua.org/manual/5.1/manual.html#lua_pushthread lua_pushthread>.
 pushthread :: LuaState -> IO Bool
 pushthread l = liftM (/= 0) (c_lua_pushthread l)
 
--- | See @lua_pushvalue@ in Lua Reference Manual.
+-- | See <https://www.lua.org/manual/5.1/manual.html#lua_pushvalue lua_pushvalue>.
 pushvalue :: LuaState -> Int -> IO ()
 pushvalue l n = c_lua_pushvalue l (fromIntegral n)
 
--- | See @lua_rawequal@ in Lua Reference Manual.
+-- | See <https://www.lua.org/manual/5.1/manual.html#lua_rawequal lua_rawequal>.
 rawequal :: LuaState -> Int -> Int -> IO Bool
 rawequal l n m = liftM (/= 0) (c_lua_rawequal l (fromIntegral n) (fromIntegral m))
 
--- | See @lua_rawget@ in Lua Reference Manual.
+-- | See <https://www.lua.org/manual/5.1/manual.html#lua_rawget lua_rawget>.
 rawget :: LuaState -> Int -> IO ()
 rawget l n = c_lua_rawget l (fromIntegral n)
 
--- | See @lua_rawgeti@ in Lua Reference Manual.
+-- | See <https://www.lua.org/manual/5.1/manual.html#lua_rawgeti lua_rawgeti>.
 rawgeti :: LuaState -> Int -> Int -> IO ()
 rawgeti l k m = c_lua_rawgeti l (fromIntegral k) (fromIntegral m)
 
--- | See @lua_rawset@ in Lua Reference Manual.
+-- | See <https://www.lua.org/manual/5.1/manual.html#lua_rawset lua_rawset>.
 rawset :: LuaState -> Int -> IO ()
 rawset l n = c_lua_rawset l (fromIntegral n)
 
--- | See @lua_rawseti@ in Lua Reference Manual.
+-- | See <https://www.lua.org/manual/5.1/manual.html#lua_rawseti lua_rawseti>.
 rawseti :: LuaState -> Int -> Int -> IO ()
 rawseti l k m = c_lua_rawseti l (fromIntegral k) (fromIntegral m)
 
--- | See @lua_remove@ in Lua Reference Manual.
+-- | See <https://www.lua.org/manual/5.1/manual.html#lua_remove lua_remove>.
 remove :: LuaState -> Int -> IO ()
 remove l n = c_lua_remove l (fromIntegral n)
 
--- | See @lua_replace@ in Lua Reference Manual.
+-- | See <https://www.lua.org/manual/5.1/manual.html#lua_replace lua_replace>.
 replace :: LuaState -> Int -> IO ()
 replace l n = c_lua_replace l (fromIntegral n)
 
--- | See @lua_resume@ in Lua Reference Manual.
+-- | See <https://www.lua.org/manual/5.1/manual.html#lua_resume lua_resume>.
 resume :: LuaState -> Int -> IO Int
 resume l n = liftM fromIntegral (c_lua_resume l (fromIntegral n))
 
--- | See @lua_setfenv@ in Lua Reference Manual.
+-- | See <https://www.lua.org/manual/5.1/manual.html#lua_setfenv lua_setfenv>.
 setfenv :: LuaState -> Int -> IO Int
 setfenv l n = liftM fromIntegral (c_lua_setfenv l (fromIntegral n))
 
--- | See @lua_setmetatable@ in Lua Reference Manual.
+-- | See <https://www.lua.org/manual/5.1/manual.html#lua_setmetatable lua_setmetatable>.
 setmetatable :: LuaState -> Int -> IO ()
 setmetatable l n = c_lua_setmetatable l (fromIntegral n)
 
--- | See @lua_settable@ in Lua Reference Manual.
+-- | See <https://www.lua.org/manual/5.1/manual.html#lua_settable lua_settable>.
 settable :: LuaState -> Int -> IO ()
 settable l index = c_lua_settable l (fromIntegral index)
 
 
--- | See @lua_status@ in Lua Reference Manual.
+-- | See <https://www.lua.org/manual/5.1/manual.html#lua_status lua_status>.
 status :: LuaState -> IO Int
 status l = liftM fromIntegral (c_lua_status l)
 
--- | See @lua_toboolean@ in Lua Reference Manual.
+-- | See <https://www.lua.org/manual/5.1/manual.html#lua_toboolean lua_toboolean>.
 toboolean :: LuaState -> Int -> IO Bool
 toboolean l n = liftM (/= 0) (c_lua_toboolean l (fromIntegral n))
 
--- | See @lua_tocfunction@ in Lua Reference Manual.
+-- | See <https://www.lua.org/manual/5.1/manual.html#lua_tocfunction lua_tocfunction>.
 tocfunction :: LuaState -> Int -> IO (FunPtr LuaCFunction)
 tocfunction l n = c_lua_tocfunction l (fromIntegral n)
 
--- | See @lua_tointeger@ in Lua Reference Manual.
+-- | See <https://www.lua.org/manual/5.1/manual.html#lua_tointeger lua_tointeger>.
 tointeger :: LuaState -> Int -> IO LuaInteger
 tointeger l n = c_lua_tointeger l (fromIntegral n)
 
--- | See @lua_tonumber@ in Lua Reference Manual.
+-- | See <https://www.lua.org/manual/5.1/manual.html#lua_tonumber lua_tonumber>.
 tonumber :: LuaState -> Int -> IO LuaNumber
 tonumber l n = c_lua_tonumber l (fromIntegral n)
 
--- | See @lua_topointer@ in Lua Reference Manual.
+-- | See <https://www.lua.org/manual/5.1/manual.html#lua_topointer lua_topointer>.
 topointer :: LuaState -> Int -> IO (Ptr ())
 topointer l n = c_lua_topointer l (fromIntegral n)
 
--- | See @lua_register@ in Lua Reference Manual.
+-- | See <https://www.lua.org/manual/5.1/manual.html#lua_register lua_register>.
 register :: LuaState -> String -> FunPtr LuaCFunction -> IO ()
 register l n f = do
     pushcclosure l f 0
     setglobal l n
 
--- | See @luaL_newmetatable@ in Lua Reference Manual.
+-- | See <https://www.lua.org/manual/5.1/manual.html#luaL_newmetatable luaL_newmetatable>.
 newmetatable :: LuaState -> String -> IO Int
 newmetatable l s = withCString s $ \sPtr -> liftM fromIntegral (c_luaL_newmetatable l sPtr)
 
--- | See @luaL_argerror@ in Lua Reference Manual. Contrary to the
+-- | See <https://www.lua.org/manual/5.1/manual.html#luaL_argerror luaL_argerror>. Contrary to the
 -- manual, Haskell function does return with value less than zero.
 argerror :: LuaState -> Int -> String -> IO CInt
 argerror l n msg = withCString msg $ \msgPtr -> do
@@ -523,11 +531,11 @@ argerror l n msg = withCString msg $ \msgPtr -> do
     -- here we should have error message string on top of the stack
     return (-1)
 
--- | See @luaL_ref@ in Lua Reference Manual.
+-- | See <https://www.lua.org/manual/5.1/manual.html#luaL_ref luaL_ref>.
 ref :: LuaState -> Int -> IO Int
 ref l n = fmap fromIntegral $ c_luaL_ref l (fromIntegral n)
 
--- | See @luaL_unref@ in Lua Reference Manual.
+-- | See <https://www.lua.org/manual/5.1/manual.html#luaL_unref luaL_unref>.
 unref :: LuaState -> Int -> Int -> IO ()
 unref l t r = c_luaL_unref l (fromIntegral t) (fromIntegral r)
 

--- a/src/Scripting/Lua.hsc
+++ b/src/Scripting/Lua.hsc
@@ -116,6 +116,7 @@ pushcclosure l f n = c_lua_pushcclosure l f (fromIntegral n)
 pushcfunction :: LuaState -> FunPtr LuaCFunction -> IO ()
 pushcfunction l f = pushcclosure l f 0
 
+{-# DEPRECATED strlen "Use objlen instead." #-}
 -- | Compatibility alias for objlen
 strlen :: LuaState -> Int -> IO Int
 strlen = objlen


### PR DESCRIPTION
I think these links are more helpful than just saying it's in the manual.

lua_strlen was deprecated in Lua 5.1. I noticed that when I went to add the link. http://lua-users.org/lists/lua-l/2009-03/msg00353.html

If someone with more knowledge than me could document the remaining functions, that would be great.