### PR TITLE
created flag use-pkgconfig to simplify building against system libraries

### DIFF
--- a/hslua.cabal
+++ b/hslua.cabal
@@ -64,7 +64,7 @@ library
   hs-source-dirs:       src
   ghc-options:          -Wall -O2
   extensions:           CPP
-  if flag(system-lua) || flag(luajit)
+  if flag(system-lua) || flag(luajit) || flag(lua501) || flag(lua502)
     if flag(luajit)
       if flag(use-pkgconfig)
         pkgconfig-depends: luajit

--- a/hslua.cabal
+++ b/hslua.cabal
@@ -51,6 +51,10 @@ flag lua502
   description:          Build against lua 5.2.
   default:              False
 
+flag use-pkgconfig
+  description:          Build using pkg-config to discover library and include paths. This is only used with system-lua and luajit.
+  default:              False
+
 library
   build-depends:        base       >= 4.7    && < 5,
                         bytestring >= 0.10.2 && < 0.11
@@ -62,10 +66,23 @@ library
   extensions:           CPP
   if flag(system-lua) || flag(luajit)
     if flag(luajit)
-      Extra-libraries:  luajit-5.1
+      if flag(use-pkgconfig)
+        pkgconfig-depends: luajit
+      else
+        Extra-libraries:  luajit-5.1
     else
-      Extra-libraries:  lua
-    includes:           lua.h
+      if flag(use-pkgconfig)
+        if flag(lua501)
+          pkgconfig-depends: lua5.1
+        else
+          if flag(lua502)
+            pkgconfig-depends: lua5.2
+          else
+            pkgconfig-depends: lua5.3
+      else
+        Extra-libraries:  lua
+    if !flag(use-pkgconfig)
+      includes:         lua.h
   else
     c-sources:          lua-5.3.4/lapi.c
                       , lua-5.3.4/lcode.c

--- a/src/Foreign/Lua.hsc
+++ b/src/Foreign/Lua.hsc
@@ -199,7 +199,7 @@ yield l n = liftM fromIntegral (c_lua_yield l (fromIntegral n))
 checkstack :: LuaState -> Int -> IO Bool
 checkstack l n = liftM (/= 0) (c_lua_checkstack l (fromIntegral n))
 
--- | See @lua_newstate@ and <https://www.lua.org/manual/LUA_VERSION_MAJORMINOR/manual.html#luaL_newstate luaL_newstate>.
+-- | See <https://www.lua.org/manual/LUA_VERSION_MAJORMINOR/manual.html#luaL_newstate luaL_newstate>.
 newstate :: IO LuaState
 newstate = do
     l <- c_luaL_newstate
@@ -215,7 +215,7 @@ close = c_lua_close
 concat :: LuaState -> Int -> IO ()
 concat l n = c_lua_concat l (fromIntegral n)
 
--- | See @lua_call@ and <https://www.lua.org/manual/LUA_VERSION_MAJORMINOR/manual.html#lua_call lua_call>.
+-- | See <https://www.lua.org/manual/LUA_VERSION_MAJORMINOR/manual.html#lua_call lua_call>.
 call :: LuaState -> NumArgs -> NumResults -> IO ()
 #if LUA_VERSION_NUMBER >= 502
 call l a nresults =

--- a/src/Foreign/Lua/Types.hsc
+++ b/src/Foreign/Lua/Types.hsc
@@ -64,28 +64,28 @@ import Foreign.Ptr
 
 #include "lua.h"
 
--- | Synonym for @lua_State *@. See @lua_State@ in Lua Reference Manual.
+-- | Synonym for @lua_State *@. See <https://www.lua.org/manual/LUA_VERSION_MAJORMINOR/manual.html#lua_State lua_State>.
 newtype LuaState = LuaState (Ptr ())
 
--- | Synonym for @lua_Alloc@. See @lua_Alloc@ in Lua Reference Manual.
+-- | Synonym for @lua_Alloc@. See <https://www.lua.org/manual/LUA_VERSION_MAJORMINOR/manual.html#lua_Alloc lua_Alloc>.
 type LuaAlloc = Ptr () -> Ptr () -> CSize -> CSize -> IO (Ptr ())
 
--- | Synonym for @lua_Reader@. See @lua_Reader@ in Lua Reference Manual.
+-- | Synonym for @lua_Reader@. See <https://www.lua.org/manual/LUA_VERSION_MAJORMINOR/manual.html#lua_Reader lua_Reader>.
 type LuaReader = Ptr () -> Ptr () -> Ptr CSize -> IO (Ptr CChar)
 
--- | Synonym for @lua_Writer@. See @lua_Writer@ in Lua Reference Manual.
+-- | Synonym for @lua_Writer@. See <https://www.lua.org/manual/LUA_VERSION_MAJORMINOR/manual.html#lua_Writer lua_Writer>.
 type LuaWriter = LuaState -> Ptr CChar -> CSize -> Ptr () -> IO CInt
 
--- | Synonym for @lua_CFunction@. See @lua_CFunction@ in Lua Reference Manual.
+-- | Synonym for @lua_CFunction@. See <https://www.lua.org/manual/LUA_VERSION_MAJORMINOR/manual.html#lua_CFunction lua_CFunction>.
 type LuaCFunction = LuaState -> IO CInt
 
--- | Synonym for @lua_Integer@. See @lua_Integer@ in Lua Reference Manual.
+-- | Synonym for @lua_Integer@. See <https://www.lua.org/manual/LUA_VERSION_MAJORMINOR/manual.html#lua_Integer lua_Integer>.
 type LuaInteger = #{type LUA_INTEGER}
 
--- | Synonym for @lua_Number@. See @lua_Number@ in Lua Reference Manual.
+-- | Synonym for @lua_Number@. See <https://www.lua.org/manual/LUA_VERSION_MAJORMINOR/manual.html#lua_Number lua_Number>.
 type LuaNumber = #{type LUA_NUMBER}
 
--- | Enumeration used as type tag. See @lua_type@ in Lua Reference Manual.
+-- | Enumeration used as type tag. See <https://www.lua.org/manual/LUA_VERSION_MAJORMINOR/manual.html#lua_type lua_type>.
 data LTYPE
   = TNONE
   | TNIL
@@ -170,6 +170,6 @@ newtype NumArgs = NumArgs { fromNumArgs :: CInt }
 newtype NumResults = NumResults { fromNumResults :: CInt }
   deriving (Enum, Eq, Integral, Num, Ord, Real, Show)
 
--- | Alias for C constant @LUA_MULTRET@. See <https://www.lua.org/manual/5.1/manual.html#lua_call lua_call>.
+-- | Alias for C constant @LUA_MULTRET@. See <https://www.lua.org/manual/LUA_VERSION_MAJORMINOR/manual.html#lua_call lua_call>.
 multret :: NumResults
 multret = NumResults $ #{const LUA_MULTRET}

--- a/test/HsLuaSpec.hs
+++ b/test/HsLuaSpec.hs
@@ -163,7 +163,6 @@ testStackValueInstance t = QM.monadicIO $ do
 testOpen :: String -> (LuaState -> IO ())  -> Test
 testOpen lib openfn = TestLabel ("open" ++ lib) . TestCase . assert $ do
     l <- newstate
-    openlibs l
     openfn l
     ret <- istable l (-1)
     close l
@@ -172,7 +171,6 @@ testOpen lib openfn = TestLabel ("open" ++ lib) . TestCase . assert $ do
 testOpenBase :: Test
 testOpenBase = TestLabel "openbase" . TestCase . assert $ do
     l <- newstate
-    openlibs l
     openbase l
     -- openbase returns one table in lua 5.2 and later
 #if LUA_VERSION_NUMBER >= 502

--- a/test/simple-test.hs
+++ b/test/simple-test.hs
@@ -2,6 +2,7 @@
 
 module Main where
 
+import Control.Monad
 import qualified Foreign.Lua as Lua
 
 main :: IO ()
@@ -12,4 +13,10 @@ main = do
     Lua.pushstring l "Hello from"
     Lua.getglobal l "_VERSION"
     Lua.call l 2 0
+    Lua.getglobal l "jit"
+    isLuajit <- Lua.istable l (-1)
+    when isLuajit $ do
+        Lua.getglobal l "print"
+        Lua.getfield l (-2) "version"
+        Lua.call l 1 0
     Lua.close l


### PR DESCRIPTION
Flags lua501 and lua502 should imply system-lua or they result in a compile error.
I added a print of the luajit version. It used to be printed from inspect. It was useful to make sure that things were successfully compiled against luajit.