### PR TITLE
Speed up travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 sudo: false
 language: generic
 
-apt:
-  - alex-3.1.4
-
 # Speed builds up by caching install requirements
 cache:
   directories:
@@ -14,37 +11,42 @@ cache:
 matrix:
   allow_failures:
     # Coverage is currently broken, so allow failure
-    - env: GHCVER=8.0.2 CABALVER=1.24 COVERAGE=true
+    - env: GHCVER=8.0.2 CABALVER=1.24 LUAVER=default COVERAGE=true
   include:
+    # Default test
+    - env: GHCVER=8.0.2 CABALVER=1.24 LUAVER=default COVERAGE=true
+      compiler: ": #GHC 8.0.2"
+      addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.2], sources: [hvr-ghc]}}
+    # Test GHC 7.8
     - env: GHCVER=7.8.4 CABALVER=1.20 LUAVER=default
       compiler: ": #GHC 7.8.4"
       addons: {apt: {packages: [cabal-install-1.20,ghc-7.8.4], sources: [hvr-ghc]}}
-    - env: GHCVER=7.8.4 CABALVER=1.20 LUAVER=lua-5.1.5
-      compiler: ": #GHC 7.8.4"
-      addons: {apt: {packages: [cabal-install-1.20,ghc-7.8.4], sources: [hvr-ghc]}}
-    - env: GHCVER=7.8.4 CABALVER=1.20 LUAVER=lua-5.2.4
-      compiler: ": #GHC 7.8.4"
-      addons: {apt: {packages: [cabal-install-1.20,ghc-7.8.4], sources: [hvr-ghc]}}
-    - env: GHCVER=7.8.4 CABALVER=1.20 LUAVER=lua-5.3.4
-      compiler: ": #GHC 7.8.4"
-      addons: {apt: {packages: [cabal-install-1.20,ghc-7.8.4], sources: [hvr-ghc]}}
-    - env: GHCVER=7.8.4 CABALVER=1.20 LUAVER=luajit
-      compiler: ": #GHC 7.8.4"
-      addons: {apt: {packages: [cabal-install-1.20,ghc-7.8.4], sources: [hvr-ghc]}}
-
-    - env: GHCVER=8.0.2 CABALVER=1.24 LUAVER=default
+    # Test GHC 7.10
+    - env: GHCVER=7.10.3 CABALVER=1.20 LUAVER=default
+      compiler: ": #GHC 7.10.3"
+      addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3], sources: [hvr-ghc]}}
+    # Test system Lua 5.1
+    - env: GHCVER=8.0.2 CABALVER=1.24 LUAVER=lua-5.1.5
       compiler: ": #GHC 8.0.2"
       addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.2], sources: [hvr-ghc]}}
-
-    - env: GHCVER=8.0.2 CABALVER=1.24 COVERAGE=true
+    # Test system Lua 5.2
+    - env: GHCVER=8.0.2 CABALVER=1.24 LUAVER=lua-5.2.4
       compiler: ": #GHC 8.0.2"
-      addons: {apt: {packages: [cabal-install-1.20,ghc-8.0.2], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.2], sources: [hvr-ghc]}}
+    # Test system Lua 5.3
+    - env: GHCVER=8.0.2 CABALVER=1.24 LUAVER=lua-5.3.4
+      compiler: ": #GHC 8.0.2"
+      addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.2], sources: [hvr-ghc]}}
+    # Test luajit
+    - env: GHCVER=8.0.2 CABALVER=1.24 LUAVER=luajit
+      compiler: ": #GHC 8.0.2"
+      addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.2], sources: [hvr-ghc]}}
 
   # mark build as successful as soon as all required successes are in.
   fast_finish: true
 
 before_install:
-  - export PATH=/opt/alex/3.1.4/bin:/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$PATH
+  - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$PATH
   - cabal update
 
 install:
@@ -57,6 +59,7 @@ script:
     case "$LUAVER" in
       (lua-5*):
           # Install Lua
+          # TODO: test for existing install and skip if one is found
           wget http://www.lua.org/ftp/${LUAVER}.tar.gz
           tar -xf ${LUAVER}.tar.gz
           cd ${LUAVER}
@@ -71,10 +74,12 @@ script:
           CABAL_CONFIG_ARGS="$CABAL_CONFIG_ARGS --extra-lib-dirs=${HOME}/usr/lib"
           ;;
       (luajit):
-          # Install LuaJIT 2.0.3
-          wget http://luajit.org/download/LuaJIT-2.0.3.tar.gz
-          tar -xf LuaJIT-2.0.3.tar.gz
-          cd LuaJIT-2.0.3
+          # Install LuaJIT
+          # TODO: test for existing install and skip if one is found
+          export LUAJIT_VERSION=2.0.4
+          wget http://luajit.org/download/LuaJIT-${LUAJIT_VERSION}.tar.gz
+          tar -xf LuaJIT-${LUAJIT_VERSION}.tar.gz
+          cd LuaJIT-${LUAJIT_VERSION}
           sed -i 's/^TARGET_CC= $(STATIC_CC)/TARGET_CC= $(DYNAMIC_CC)/g' src/Makefile
           make
           make install PREFIX=${HOME}/usr

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,20 +9,17 @@ cache:
   - $HOME/usr
 
 matrix:
-  allow_failures:
-    # Coverage is currently broken, so allow failure
-    - env: GHCVER=8.0.2 CABALVER=1.24 LUAVER=default COVERAGE=true
   include:
     # Default test
     - env: GHCVER=8.0.2 CABALVER=1.24 LUAVER=default COVERAGE=true
       compiler: ": #GHC 8.0.2"
       addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.2], sources: [hvr-ghc]}}
     # Test GHC 7.8
-    - env: GHCVER=7.8.4 CABALVER=1.20 LUAVER=default
+    - env: GHCVER=7.8.4 CABALVER=1.18 LUAVER=default
       compiler: ": #GHC 7.8.4"
-      addons: {apt: {packages: [cabal-install-1.20,ghc-7.8.4], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4], sources: [hvr-ghc]}}
     # Test GHC 7.10
-    - env: GHCVER=7.10.3 CABALVER=1.20 LUAVER=default
+    - env: GHCVER=7.10.3 CABALVER=1.22 LUAVER=default
       compiler: ": #GHC 7.10.3"
       addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3], sources: [hvr-ghc]}}
     # Test system Lua 5.1
@@ -53,7 +50,7 @@ install:
   - cabal install --only-dependencies --enable-tests
 
 script:
-  - export CABAL_CONFIG_ARGS="--enable-tests"
+  - CABAL_CONFIG_ARGS=""
   - if [ -n "${COVERAGE}" ]; then CABAL_CONFIG_ARGS="--enable-library-coverage"; fi
   - |
     case "$LUAVER" in
@@ -101,7 +98,7 @@ script:
     esac
   - export LD_LIBRARY_PATH=${HOME}/usr/lib:$LD_LIBRARY_PATH
   - echo $CABAL_CONFIG_ARGS
-  - cabal configure $CABAL_CONFIG_ARGS
+  - cabal configure --enable-tests --disable-optimization --ghc-options="-j +RTS -A128m -n2m -RTS" $CABAL_CONFIG_ARGS
   - cabal build
   - cabal test
   - cabal copy
@@ -113,5 +110,5 @@ after_success:
   - if [ -n "${COVERAGE}" ]; then
       cabal sandbox init;
       cabal install hpc-coveralls;
-      ./.cabal-sandbox/bin/hpc-coveralls simple-test callbacks haskellfun err_prop test;
+      .cabal-sandbox/bin/hpc-coveralls simple-test callbacks haskellfun err_prop test;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ before_install:
 install:
   - echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
   - echo "$(cabal --version)"
-  - cabal install --only-dependencies --enable-tests
+  - cabal install --only-dependencies --enable-tests --disable-optimization
 
 script:
   - CABAL_CONFIG_ARGS=""
@@ -110,7 +110,6 @@ after_success:
   - set -e
   - set -x
   - if [ -n "${COVERAGE}" ]; then
-      cabal sandbox init;
-      cabal install hpc-coveralls;
-      .cabal-sandbox/bin/hpc-coveralls simple-test callbacks haskellfun err_prop test;
+      cabal install --disable-optimization hpc-coveralls;
+      hpc-coveralls simple-test callbacks haskellfun err_prop test;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,8 @@ before_install:
   - cabal update
 
 install:
+  - echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
+  - echo "$(cabal --version)"
   - cabal install --only-dependencies --enable-tests
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ matrix:
   fast_finish: true
 
 before_install:
-  - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$PATH
+  - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$HOME/.cabal/bin:$PATH
   - cabal update
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -98,7 +98,7 @@ script:
     esac
   - export LD_LIBRARY_PATH=${HOME}/usr/lib:$LD_LIBRARY_PATH
   - echo $CABAL_CONFIG_ARGS
-  - cabal configure --enable-tests --disable-optimization --ghc-options="-j +RTS -A128m -n2m -RTS" $CABAL_CONFIG_ARGS
+  - cabal configure --enable-tests --disable-optimization --ghc-options="-Werror" $CABAL_CONFIG_ARGS
   - cabal build
   - cabal test
   - cabal copy

--- a/test/HsLuaSpec.hs
+++ b/test/HsLuaSpec.hs
@@ -1,10 +1,6 @@
 {-# LANGUAGE CPP #-}
 module HsLuaSpec where
 
-#if MIN_VERSION_base(4,8,0)
-#else
-import Control.Applicative ( (<$>), (<*>) )
-#endif
 import Control.Monad (forM, forM_, when)
 import Data.ByteString (ByteString)
 import qualified Data.ByteString.Char8 as B


### PR DESCRIPTION
The net result of this isn't too much of a change. ghc 8.0 seems to be quite a bit slower than ghc 7.8.

Use ghc 8.0 for testing the different versions of Lua.

Added --disable-optimization flag to hslua build and cabal install to speed up compilation.

Fixed cabal version mismatch that was causing the coverage to fail. Removed the allow failure.

Added -Werror to help catch warnings. Fixed warning with ghc 7.8 and Control.Applicative. Maybe it was 7.6 that needed that section.

Changed cabal version to 1.18 for ghc 7.8 as it seemed more appropriate.